### PR TITLE
docs: add missing link to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ https://near.zulipchat.com/
 For non-technical discussion and overall direction of the project, see our Discourse forum:
 
 https://gov.near.org
+docs: added missing link to Near documentation site


### PR DESCRIPTION
Added a link to the official Near documentation site for easier onboarding. 
Docs only.
